### PR TITLE
Width issue (#73) fixed; not height. Also fixes plot menu.

### DIFF
--- a/www/pgm2/hausautomatisierung_comstyle.css
+++ b/www/pgm2/hausautomatisierung_comstyle.css
@@ -256,3 +256,6 @@ svg:not([fill]):not(.jssvg) { fill: #676f7a; }
 #right > ul ul, #right > div ul, #right > div > ul ul, #right > p ul { list-style-type: square; margin-left: 20px; }
 #right > ul ul li, #right > div ul li, #right > div > ul ul li, #right > p ul li { margin: 10px 0; }
 #right > ul table td, #right > div table td, #right > div > ul table td, #right > p table td { padding: 5px; }
+
+#fwmenu { position: absolute; z-index: 999; }
+div.CodeMirror.cm-s-blackboard { width: auto; }


### PR DESCRIPTION
CodeMirror blackboard becomes correct width; but not height.
Plot menu of svg plots (#fwmenu) will be shown underneath click.