### PR TITLE
Line breaks in SVG "Example lines for input:"

### DIFF
--- a/sass/_content.scss
+++ b/sass/_content.scss
@@ -365,7 +365,7 @@
 
         .ex {
             max-width: $maxWidthContent;
-            white-space: normal;
+            white-space: pre;
         }
 
         input + select,


### PR DESCRIPTION
Right now the exampels contains "\n" for line-breaking. This does not lead to an html line break... see example below

Example lines for input:
2019-12-25_08:53:22 KG.Waschkueche.Bewegungsmelder Activity: alive 2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder battery: ok 2019-12-25_08:53:21 KG.Waschkueche.Bewegungsmelder batteryState: ok 2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder battery_level: 80 2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder illuminance: 0 2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder linkquality: 52 2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder lux: 0 2019-12-25_08:53:22 KG.Waschkueche.Bewegungsmelder m: 0 2019-12-24_21:04:15 KG.Waschkueche.Bewegungsmelder motion 2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder no_motion 2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder occupancy: false 2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder transmission-state: incoming publish received 2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder voltage: 2965 

by changing wordwrap to pre it gets way easier to read:

Example lines for input:
2019-12-25_08:53:22 KG.Waschkueche.Bewegungsmelder Activity: alive
2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder battery: ok
2019-12-25_08:53:21 KG.Waschkueche.Bewegungsmelder batteryState: ok
2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder battery_level: 80
2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder illuminance: 0
2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder linkquality: 52
2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder lux: 0
2019-12-25_08:53:22 KG.Waschkueche.Bewegungsmelder m: 0
2019-12-24_21:04:15 KG.Waschkueche.Bewegungsmelder motion
2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder no_motion
2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder occupancy: false
2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder transmission-state: incoming publish received
2019-12-25_08:20:01 KG.Waschkueche.Bewegungsmelder voltage: 2965