### PR TITLE
Update _content.scss

### DIFF
--- a/sass/_content.scss
+++ b/sass/_content.scss
@@ -239,11 +239,8 @@
         }
     }
 
-    > table {
-        width: 100%;
-    }
-
     table {
+        width: 100%;
         border-collapse: collapse;
         max-width: $maxWidthContent;
 
@@ -254,6 +251,9 @@
             border-bottom: 1px $secondary-color solid;
         }
 
+        &.roomoverview {
+            margin-bottom: 20px;
+        }
         &.wide,
         &.roomoverview {
             width: 100%;


### PR DESCRIPTION
Fixing two bugs with readingsgroup visualization.

1. Fixing BugReport #113
2. Adding some space between elements when there is no group for readinggroup, see attached screenshots.
![before fix](https://user-images.githubusercontent.com/334267/71782796-90fd8380-2fde-11ea-9f0e-ea626847b17b.PNG)

![after fix](https://user-images.githubusercontent.com/334267/71782795-90fd8380-2fde-11ea-95eb-9cf286f78f24.PNG)


