### PR TITLE
SVG Ticks sichtbar gemacht

### DIFF
--- a/sass/hausautomatisierung_comsvg_style.scss
+++ b/sass/hausautomatisierung_comsvg_style.scss
@@ -42,6 +42,7 @@ svg {
     }
 
     polyline.SVGplot {
+        stroke: gray;
         fill: none;
     }
 


### PR DESCRIPTION
Siehe dazu auch Bug #116

![ticks](https://user-images.githubusercontent.com/334267/71787091-65e15700-3013-11ea-9dd6-f3f1859d0233.PNG)
